### PR TITLE
Adapt to edupage api changes

### DIFF
--- a/packages/asc-scrapper/src/client.ts
+++ b/packages/asc-scrapper/src/client.ts
@@ -5,6 +5,7 @@ import {
     ClassesTableRow,
     ClassroomsTableRow,
     DaysDefsTableRow,
+    DaysTableRow,
     DivisionsTableRow,
     GroupsTableRow,
     LessonsTableRow,
@@ -13,17 +14,16 @@ import {
     SubjectsTableRow,
     TeachersTableRow,
     TermsDefsTableRow,
+    TermsTableRow,
     TimetableVersion,
     TimetableVersionInfo,
     TimetableVersionListRaw,
     TimetableVersionRaw,
     WeeksDefsTableRow,
+    WeeksTableRow,
 } from './types.js';
 import {
     mapPeriodsTableRow,
-    mapDaysDefTableRow,
-    mapWeeksDefTableRow,
-    mapTermsDefTableRow,
     mapClassroomsTableRow,
     mapClassesTableRow,
     mapSubjectsTableRow,
@@ -91,6 +91,9 @@ export class Client {
         const daysDefsTableRows = getTableRowsById<DaysDefsTableRow>(tables, 'daysdefs');
         const weeksDefsTableRows = getTableRowsById<WeeksDefsTableRow>(tables, 'weeksdefs');
         const termsDefsTableRows = getTableRowsById<TermsDefsTableRow>(tables, 'termsdefs');
+        const daysTableRows = getTableRowsById<DaysTableRow>(tables, 'daysdefs');
+        const weeksTableRows = getTableRowsById<WeeksTableRow>(tables, 'weeksdefs');
+        const termsTableRows = getTableRowsById<TermsTableRow>(tables, 'termsdefs');
         const buildingsTableRows = getTableRowsById<BuildingsTableRow>(tables, 'buildings');
         const classroomsTableRows = getTableRowsById<ClassroomsTableRow>(tables, 'classrooms');
         const classesTableRows = getTableRowsById<ClassesTableRow>(tables, 'classes');
@@ -102,12 +105,31 @@ export class Client {
         const lessonsTableRows = getTableRowsById<LessonsTableRow>(tables, 'lessons');
         const cardsTableRows = getTableRowsById<CardsTableRow>(tables, 'cards');
 
+        const days = daysTableRows.map((day, index) => ({
+            id: day.id,
+            name: day.name,
+            short: day.short,
+            value: daysDefsTableRows[index].vals[0],
+        }));
+        const weeks = weeksTableRows.map((day, index) => ({
+            id: day.id,
+            name: day.name,
+            short: day.short,
+            value: weeksDefsTableRows[index].vals[0],
+        }));
+        const periods = termsTableRows.map((day, index) => ({
+            id: day.id,
+            name: day.name,
+            short: day.short,
+            value: termsDefsTableRows[index].vals[0],
+        }));
+
         return {
             common: {
                 timeSlots: periodsTableRow.map(mapPeriodsTableRow),
-                days: daysDefsTableRows.filter((daysDef) => daysDef.typ === 'one').map(mapDaysDefTableRow),
-                weeks: weeksDefsTableRows.filter((weeksDef) => weeksDef.typ === 'one').map(mapWeeksDefTableRow),
-                periods: termsDefsTableRows.filter((termsDef) => termsDef.typ === 'one').map(mapTermsDefTableRow),
+                days,
+                weeks,
+                periods,
                 buildings: buildingsTableRows,
                 rooms: classroomsTableRows.map(mapClassroomsTableRow),
                 classes: classesTableRows.map(mapClassesTableRow),
@@ -127,35 +149,35 @@ export class Client {
                             cardsRow.weeks !== '',
                     );
                     return cards.map((cardsRow) => {
-                        const daysDefRow = daysDefsTableRows.find(
-                            (daysDef) => daysDef.typ === 'one' && daysDef.vals.includes(cardsRow.days),
+                        const day = days.find(
+                            (day) => day.value === cardsRow.days,
                         );
-                        const weeksDefRow = weeksDefsTableRows.find(
-                            (weeksDef) => weeksDef.typ === 'one' && weeksDef.vals.includes(cardsRow.weeks),
+                        const week = weeks.find(
+                            (week) => week.value === cardsRow.weeks,
                         );
-                        const termsDefRow = termsDefsTableRows.find(
-                            (termsDef) => termsDef.typ === 'one' && termsDef.vals.includes(lessonsRow.terms),
+                        const period = periods.find(
+                            (term) => term.value === lessonsRow.terms,
                         );
-                        if (!daysDefRow) {
-                            throw Error('Missing daysDefRow');
-                        };
-                        if (!weeksDefRow) {
-                            throw Error('Missing weeksDefRow');
-                        };
-                        if (!termsDefRow) {
-                            throw Error('Missing termsDefRow');
-                        };
+                        if (!day) {
+                            throw Error('Missing day');
+                        }
+                        if (!week) {
+                            throw Error('Missing week');
+                        }
+                        if (!period) {
+                            throw Error('Missing period');
+                        }
                         return {
                             id: cardsRow.id,
                             timeSlotId: cardsRow.period,
-                            dayId: daysDefRow.id,
-                            weekId: weeksDefRow.id,
+                            dayId: day.id,
+                            weekId: week.id,
                             subjectId: lessonsRow.subjectid,
                             teacherIds: lessonsRow.teacherids,
                             roomIds: cardsRow.classroomids,
                             groupIds: lessonsRow.groupids,
                             classIds: lessonsRow.classids,
-                            periodId: termsDefRow.id,
+                            periodId: period.id,
                             seminarGroup: lessonsRow.seminargroup,
                             studentIds: lessonsRow.studentids,
                         };

--- a/packages/asc-scrapper/src/mappers.ts
+++ b/packages/asc-scrapper/src/mappers.ts
@@ -2,13 +2,10 @@ import {
     ClassesTableRow,
     ClassroomsTableRow,
     Clazz,
-    Day,
-    DaysDefsTableRow,
     Division,
     DivisionsTableRow,
     Group,
     GroupsTableRow,
-    Period,
     PeriodsTableRow,
     Room,
     Student,
@@ -17,10 +14,7 @@ import {
     SubjectsTableRow,
     Teacher,
     TeachersTableRow,
-    TermsDefsTableRow,
     TimeSlot,
-    Week,
-    WeeksDefsTableRow,
 } from './types.js';
 import { parseTime } from './utils.js';
 
@@ -30,24 +24,6 @@ export const mapPeriodsTableRow = (row: PeriodsTableRow): TimeSlot => ({
     short: row.short,
     beginMinute: parseTime(row.starttime),
     endMinute: parseTime(row.endtime),
-});
-
-export const mapDaysDefTableRow = (row: DaysDefsTableRow): Day => ({
-    id: row.id,
-    name: row.name,
-    short: row.short,
-});
-
-export const mapWeeksDefTableRow = (row: WeeksDefsTableRow): Week => ({
-    id: row.id,
-    name: row.name,
-    short: row.short,
-});
-
-export const mapTermsDefTableRow = (row: TermsDefsTableRow): Period => ({
-    id: row.id,
-    name: row.name,
-    short: row.short,
 });
 
 export const mapClassroomsTableRow = (row: ClassroomsTableRow): Room => ({

--- a/packages/asc-scrapper/src/types.ts
+++ b/packages/asc-scrapper/src/types.ts
@@ -46,6 +46,24 @@ export interface TermsDefsTableRow {
     vals: string[];
 }
 
+export interface DaysTableRow {
+    id: string;
+    name: string;
+    short: string;
+}
+
+export interface WeeksTableRow {
+    id: string;
+    name: string;
+    short: string;
+}
+
+export interface TermsTableRow {
+    id: string;
+    name: string;
+    short: string;
+}
+
 export interface BuildingsTableRow {
     id: string;
     name: string;
@@ -129,6 +147,9 @@ export interface TimetableVersionRaw {
             TimetableVersionDBTable<DaysDefsTableRow>,
             TimetableVersionDBTable<WeeksDefsTableRow>,
             TimetableVersionDBTable<TermsDefsTableRow>,
+            TimetableVersionDBTable<DaysTableRow>,
+            TimetableVersionDBTable<WeeksTableRow>,
+            TimetableVersionDBTable<TermsTableRow>,
             TimetableVersionDBTable<BuildingsTableRow>,
             TimetableVersionDBTable<ClassroomsTableRow>,
             TimetableVersionDBTable<ClassesTableRow>,

--- a/packages/asc-scrapper/src/types.ts
+++ b/packages/asc-scrapper/src/types.ts
@@ -194,18 +194,21 @@ export interface Day {
     id: string;
     name: string;
     short: string;
+    value: string;
 }
 
 export interface Week {
     id: string;
     name: string;
     short: string;
+    value: string;
 }
 
 export interface Period {
     id: string;
     name: string;
     short: string;
+    value: string;
 }
 
 export interface Building {

--- a/packages/asc-scrapper/src/types.ts
+++ b/packages/asc-scrapper/src/types.ts
@@ -33,29 +33,17 @@ export interface PeriodsTableRow {
 
 export interface DaysDefsTableRow {
     id: string;
-    name: string;
-    short: string;
-    typ: 'all' | 'any' | 'one';
     vals: string[];
-    val: number | null;
 }
 
 export interface WeeksDefsTableRow {
     id: string;
-    name: string;
-    short: string;
-    typ: 'all' | 'any' | 'one';
     vals: string[];
-    val: number | null;
 }
 
 export interface TermsDefsTableRow {
     id: string;
-    name: string;
-    short: string;
-    typ: 'all' | 'any' | 'one';
     vals: string[];
-    val: number | null;
 }
 
 export interface BuildingsTableRow {


### PR DESCRIPTION
W ostatnim czasie zmieniło się parę rzeczy w strukturze danych planu lekcji w api edupage. Między innymi usunięto parę pól w tabelach `daysdefs`, `weeksdefs` oraz `termsdefs`. Ta zmiana popsuła uzyskiwanie dnia, tygodnia i semestru, w którym odbywa się dana lekcja.