### PR TITLE
Changes in optivum scrapper for new crawler

### DIFF
--- a/packages/optivum-scrapper/src/timetable.ts
+++ b/packages/optivum-scrapper/src/timetable.ts
@@ -71,7 +71,7 @@ export class Timetable {
                     list.sources.push(responseUrl);
                 }),
             );
-            list.sources = list.sources.sort();
+            list.sources.sort();
             return list;
         }
         const frame = document.querySelector('frame[name="list"][src]');

--- a/packages/optivum-scrapper/src/timetable.ts
+++ b/packages/optivum-scrapper/src/timetable.ts
@@ -3,7 +3,7 @@ import { Axios, AxiosResponse } from 'axios';
 import { AxiosCacheInstance } from 'axios-cache-interceptor';
 import { JSDOM } from 'jsdom';
 import { Table } from './table.js';
-import { Unit } from './types.js';
+import { Unit, UnitType } from './types.js';
 import { parseUnitLink, parseUnitUrl } from './utils.js';
 import { isDefined } from '@timetable-api/common';
 
@@ -38,43 +38,54 @@ export class Timetable {
         return new Table(response);
     }
 
-    public async getUnitList(): Promise<Unit[]> {
-        const { response, responseUrl } = await this.getDocument(this.baseUrl);
-        this.baseUrl = responseUrl;
+    private async getIndexPageFromScript() {
+        const scriptResponse = (await this.getDocument('../scripts/powrot.js')).response;
+        const { response, responseUrl } = await this.getDocument(
+            /<a href="(.*?)">Plan lekcji<\/a>/.exec(scriptResponse)?.[1] ?? '../index.html',
+        );
+        return [response, responseUrl];
+    }
+
+    private async getListPageFromFrame(frame: Element) {
+        const listPath = frame.getAttribute('src')!;
+        const { response, responseUrl } = await this.getDocument(listPath);
+        return [response, responseUrl];
+    }
+
+    public async getUnitList(): Promise<{ units: Unit[]; sources: string[] }> {
+        const { response } = await this.getDocument(this.baseUrl);
         let document = new JSDOM(response).window.document;
         if (document.querySelector('script[src="../scripts/powrot.js"]') !== null) {
-            const scriptResponse = (await this.getDocument('../scripts/powrot.js')).response;
-            const { response, responseUrl } = await this.getDocument(
-                /<a href="(.*?)">Plan lekcji<\/a>/.exec(scriptResponse)?.[0] ?? '../index.html',
-            );
+            const [response, responseUrl] = await this.getIndexPageFromScript();
             this.baseUrl = responseUrl;
             document = new JSDOM(response).window.document;
         }
         if (document.querySelector('.menu') !== null) {
-            const list: Unit[] = [];
+            const list: { units: Unit[]; sources: string[] } = { units: [], sources: [] };
             await Promise.all(
-                [...document.querySelectorAll('a[hidefocus="true"]')].map(async (listLink) => {
-                    const href = listLink.getAttribute('href');
-                    if (href == null) return;
-                    const { response } = await this.getDocument(href);
+                [...document.querySelectorAll('a[hidefocus="true"][href]')].map(async (listLink) => {
+                    const href = listLink.getAttribute('href')!;
+                    const { response, responseUrl } = await this.getDocument(href);
                     const unitList = this.parseUnitList(response);
-                    list.push(...unitList)
+                    list.units.push(...unitList);
+                    list.sources.push(responseUrl);
                 }),
             );
+            list.sources = list.sources.sort();
             return list;
         }
-        if (document.querySelector('frame[name="list"]')) {
-            const { response } = await this.getDocument(
-                document.querySelector('frame[name="list"]')?.getAttribute('src') ?? 'lista.html',
-            );
+        const frame = document.querySelector('frame[name="list"][src]');
+        if (frame) {
+            const [response, responseUrl] = await this.getListPageFromFrame(frame);
+            this.baseUrl = responseUrl;
             document = new JSDOM(response).window.document;
         }
-        return this.parseUnitList(document.documentElement.innerHTML);
+        return { units: this.parseUnitList(document.documentElement.innerHTML), sources: [this.baseUrl] };
     }
 
     public parseUnitList(html: string): Unit[] {
         const document: Document = new JSDOM(html).window.document;
-        let units: { type: 'o' | 'n' | 's'; id: string; fullName: string }[];
+        let units: { type: UnitType; id: string; fullName: string }[];
         if (document.querySelector('select')) {
             const selectElements = document.querySelectorAll('select');
             units = [...selectElements]

--- a/packages/optivum-scrapper/src/types.ts
+++ b/packages/optivum-scrapper/src/types.ts
@@ -1,6 +1,8 @@
+export type UnitType = 'o' | 'n' | 's';
+
 export interface Unit {
     id: string;
-    type: 'o' | 'n' | 's';
+    type: UnitType;
     fullName: string;
 }
 

--- a/packages/optivum-scrapper/src/utils.ts
+++ b/packages/optivum-scrapper/src/utils.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { createHash } from 'crypto';
-import { LessonClass, Lesson } from './types.js';
+import { LessonClass, Lesson, UnitType } from './types.js';
 
 export const parseTime = (value: string): number => {
     const [hours, minutes] = value.split(':').map((part) => parseInt(part, 10));
@@ -13,7 +13,7 @@ export const parseUnitUrl = (url: string) => {
     const match = unitUrlRegex.exec(url);
     if (match === null) return null;
     return {
-        type: match[1] as 'o' | 'n' | 's',
+        type: match[1] as  UnitType,
         id: match[2],
     };
 };
@@ -158,5 +158,8 @@ export const parseLesson = (fragment: DocumentFragment): Lesson => {
 
 export const getUnitKey = (unit: { id: string | null; short: string }) => (unit.id ?? `@${unit.short}`);
 
-export const getTimetableHash = (htmls: string[]) =>
+export const getTimetableHash = (htmls: string[]): string =>
     createHash('sha512').update(JSON.stringify(htmls.sort())).digest('hex');
+
+export const filterUnitsByType = <T>(units: ({ type: UnitType } & T)[], type: UnitType): T[] =>
+    units.filter((unit) => unit.type === type)

--- a/packages/optivum-scrapper/src/utils.ts
+++ b/packages/optivum-scrapper/src/utils.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
+import { createHash } from 'crypto';
 import { LessonClass, Lesson } from './types.js';
 
 export const parseTime = (value: string): number => {
@@ -157,3 +158,5 @@ export const parseLesson = (fragment: DocumentFragment): Lesson => {
 
 export const getUnitKey = (unit: { id: string | null; short: string }) => (unit.id ?? `@${unit.short}`);
 
+export const getTimetableHash = (htmls: string[]) =>
+    createHash('sha512').update(JSON.stringify(htmls.sort())).digest('hex');


### PR DESCRIPTION
## Zamysł

Optivum scrapper będzie wykonywał pracę częściami:

1. znajdowanie listy oddziałów, sal i nauczycieli
2. pobieranie wszystkich stron i generowanie hash'a
3. parsowanie zebranych danych

Pierwsza część będzie wykonywana bezpośrednio po znalezienu planu przez *crawler*. Ma to na celu lepsze sprawdzenie czy znaleziona strona jest faktycznie planem i czy nie został on już znaleziony. *Crawler* następnie będzie wrzucał znalezione plany do bazy danych do tabeli `optivum_candidates`.

Druga i trzecia część będzie wykonywana już przez *optivum scrapper*. Moduł pobierze wszystkie znalezione przez *crawler* plany, a następnie wykona część drugą. Jeśli otrzymany hash jest w bazie danych, część trzecia zostanie pominięta, dane takie jak identyfikator szkoły i źródło planu zostaną dodane do danych planu w bazie danych.
<ins>Ta zmiana zostanie zrobiona w innym pr. W tym zostały zrobione jedynie funkcje w optivum scrapperze, które pozwalają na wykonanie pracy częściami.</ins>