### PR TITLE
Add tiles API for school map

### DIFF
--- a/packages/api/src/db.rs
+++ b/packages/api/src/db.rs
@@ -36,6 +36,26 @@ impl Db {
         .await
     }
 
+    pub(crate) async fn get_tiles_0_5(&self, tile_lat: i16, tile_long: i16) -> sqlx::Result<Vec<School>> {
+        sqlx::query_as!(
+            School,
+            r#"SELECT
+                "name", "rspo_id", "commune_teryt" as "teryt", "geo_lat", "geo_long", "parent_rspo_id", "website_url",
+                "corresp_addr_street" as "address_street",
+                "corresp_addr_building_nr" as "address_building_number",
+                "corresp_addr_apartament_nr" as "address_apartament_number",
+                "corresp_addr_zip_code" as "address_zip_code",
+                "corresp_addr_town" as "address_town"
+                FROM "schools"
+                WHERE "tile_0_5_lat" = $1 AND "tile_0_5_long" = $2
+                ORDER BY "rspo_id""#,
+            tile_lat,
+            tile_long,
+        )
+            .fetch_all(&self.pool)
+            .await
+    }
+
     pub(crate) async fn get_school_by_rspo_id(&self, rspo_id: i32) -> sqlx::Result<Option<School>> {
         sqlx::query_as!(
             School,

--- a/packages/api/src/db.rs
+++ b/packages/api/src/db.rs
@@ -1,4 +1,4 @@
-use crate::entities::{OptivumTimetableVersion, School, TilesInfo};
+use crate::entities::{ClusterMarker, OptivumTimetableVersion, School, TilesInfo};
 use crate::error;
 use crate::error::ApiError;
 use sqlx::postgres::PgPoolOptions;
@@ -67,6 +67,20 @@ impl Db {
                 FROM "schools""#,
         )
             .fetch_one(&self.pool)
+            .await
+    }
+
+    pub(crate) async fn get_commune_markers(&self) -> sqlx::Result<Vec<ClusterMarker>> {
+        sqlx::query_as!(
+            ClusterMarker,
+            r#"SELECT
+                count AS "count!",
+                geo_long AS "geo_long!",
+                geo_lat AS "geo_lat!"
+                FROM "commune_markers"
+                WHERE count IS NOT NULL AND geo_long IS NOT NULL AND geo_lat IS NOT NULL"#,
+        )
+            .fetch_all(&self.pool)
             .await
     }
 

--- a/packages/api/src/db.rs
+++ b/packages/api/src/db.rs
@@ -1,4 +1,4 @@
-use crate::entities::{OptivumTimetableVersion, School};
+use crate::entities::{OptivumTimetableVersion, School, TilesInfo};
 use crate::error;
 use crate::error::ApiError;
 use sqlx::postgres::PgPoolOptions;
@@ -53,6 +53,20 @@ impl Db {
             tile_long,
         )
             .fetch_all(&self.pool)
+            .await
+    }
+
+    pub(crate) async fn get_tiles_0_5_info(&self) -> sqlx::Result<TilesInfo> {
+        sqlx::query_as!(
+            TilesInfo,
+            r#"SELECT
+                COALESCE(MIN("tile_0_5_lat"), 0) AS "min_lat_tile!",
+                COALESCE(MAX("tile_0_5_lat"), 0) AS "max_lat_tile!",
+                COALESCE(MIN("tile_0_5_long"), 0) AS "min_long_tile!",
+                COALESCE(MAX("tile_0_5_long"), 0) AS "max_long_tile!"
+                FROM "schools""#,
+        )
+            .fetch_one(&self.pool)
             .await
     }
 

--- a/packages/api/src/entities.rs
+++ b/packages/api/src/entities.rs
@@ -26,6 +26,13 @@ pub(crate) struct TilesInfo {
 }
 
 #[derive(Serialize, JsonSchema)]
+pub(crate) struct ClusterMarker {
+    pub(crate) count: i64,
+    pub(crate) geo_lat: f64,
+    pub(crate) geo_long: f64,
+}
+
+#[derive(Serialize, JsonSchema)]
 pub(crate) struct SchoolWithVersions {
     #[serde(flatten)]
     pub(crate) school: School,
@@ -42,4 +49,9 @@ pub(crate) struct OptivumTimetableVersion {
 #[derive(Serialize, JsonSchema)]
 pub(crate) struct SchoolListResponse {
     pub(crate) schools: Vec<School>
+}
+
+#[derive(Serialize, JsonSchema)]
+pub(crate) struct ClusterMarkersResponse {
+    pub(crate) markers: Vec<ClusterMarker>
 }

--- a/packages/api/src/entities.rs
+++ b/packages/api/src/entities.rs
@@ -18,6 +18,14 @@ pub(crate) struct School {
 }
 
 #[derive(Serialize, JsonSchema)]
+pub(crate) struct TilesInfo {
+    pub(crate) min_lat_tile: i32,
+    pub(crate) max_lat_tile: i32,
+    pub(crate) min_long_tile: i32,
+    pub(crate) max_long_tile: i32,
+}
+
+#[derive(Serialize, JsonSchema)]
 pub(crate) struct SchoolWithVersions {
     #[serde(flatten)]
     pub(crate) school: School,

--- a/packages/api/src/main.rs
+++ b/packages/api/src/main.rs
@@ -37,7 +37,9 @@ async fn default_headers_middleware(
     let mut response = next.run(request).await;
     let headers = response.headers_mut();
     headers.insert(X_CONTENT_TYPE_OPTIONS, HeaderValue::from_static("nosniff"));
-    headers.insert(CACHE_CONTROL, HeaderValue::from_static("no-cache"));
+    if !headers.contains_key(CACHE_CONTROL) {
+        headers.insert(CACHE_CONTROL, HeaderValue::from_static("no-cache"));
+    }
     response
 }
 

--- a/packages/api/src/main.rs
+++ b/packages/api/src/main.rs
@@ -20,7 +20,7 @@ use std::env;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use axum::extract::Request;
-use axum::http::header::{CACHE_CONTROL, X_CONTENT_TYPE_OPTIONS};
+use axum::http::header::{CACHE_CONTROL, CONTENT_ENCODING, CONTENT_TYPE, X_CONTENT_TYPE_OPTIONS};
 use axum::http::HeaderValue;
 use axum::middleware::Next;
 use tower::ServiceBuilder;
@@ -59,7 +59,8 @@ async fn main() {
     let mut api = OpenApi::default();
 
     let cors = CorsLayer::new()
-        .allow_origin(Any);
+        .allow_origin(Any)
+        .allow_headers([CONTENT_TYPE, CONTENT_ENCODING]);
     let headers_layer = ServiceBuilder::new()
         .layer(cors)
         .layer(axum::middleware::from_fn(default_headers_middleware));

--- a/packages/api/src/routes/schools.rs
+++ b/packages/api/src/routes/schools.rs
@@ -54,10 +54,13 @@ async fn list_schools(
 
 #[derive(Deserialize, JsonSchema)]
 struct TilesParams {
+    /// Filters schools where `FLOOR(school.geo_lat / 0.5) == tile_lat`
     tile_lat: i16,
+    /// Filters schools where `FLOOR(school.geo_long / 0.5) == tile_long`
     tile_long: i16,
 }
 
+/// List schools in a particular 0.5°x0.5 map tile.
 async fn list_tiles_0_5(
     State(db): State<Db>,
     Path(params): Path<TilesParams>,
@@ -74,7 +77,6 @@ async fn get_tiles_0_5_info(
     let info = db.get_tiles_0_5_info().await?;
     Ok::<_, ApiError>(Json(info))
 }
-
 
 #[derive(Deserialize, JsonSchema)]
 struct SchoolParams {

--- a/packages/api/src/routes/schools.rs
+++ b/packages/api/src/routes/schools.rs
@@ -18,6 +18,7 @@ pub(crate) fn create_schools_router() -> ApiRouter<Db> {
     ApiRouter::new()
         .api_route("/v1/schools", get(list_schools))
         .api_route("/v1/tiles/0.5/:tile_lat/:tile_long/schools", get(list_tiles_0_5))
+        .api_route("/v1/tiles/0.5/info", get(get_tiles_0_5_info))
         .api_route("/v1/schools/:rspo_id", get(get_school))
         .api_route(
             "/v1/optivum-versions/:id",
@@ -66,6 +67,14 @@ async fn list_tiles_0_5(
         schools
     }))
 }
+
+async fn get_tiles_0_5_info(
+    State(db): State<Db>,
+) -> impl IntoApiResponse {
+    let info = db.get_tiles_0_5_info().await?;
+    Ok::<_, ApiError>(Json(info))
+}
+
 
 #[derive(Deserialize, JsonSchema)]
 struct SchoolParams {

--- a/packages/api/src/routes/schools.rs
+++ b/packages/api/src/routes/schools.rs
@@ -1,5 +1,5 @@
 use crate::db::Db;
-use crate::entities::{SchoolListResponse, SchoolWithVersions};
+use crate::entities::{ClusterMarkersResponse, SchoolListResponse, SchoolWithVersions};
 use crate::error::ApiError;
 use aide::axum::routing::{get, post};
 use aide::axum::{ApiRouter, IntoApiResponse};
@@ -19,6 +19,7 @@ pub(crate) fn create_schools_router() -> ApiRouter<Db> {
         .api_route("/v1/schools", get(list_schools))
         .api_route("/v1/tiles/0.5/:tile_lat/:tile_long/schools", get(list_tiles_0_5))
         .api_route("/v1/tiles/0.5/info", get(get_tiles_0_5_info))
+        .api_route("/v1/cluster-markers/commune", get(get_commune_markers))
         .api_route("/v1/schools/:rspo_id", get(get_school))
         .api_route(
             "/v1/optivum-versions/:id",
@@ -76,6 +77,15 @@ async fn get_tiles_0_5_info(
 ) -> impl IntoApiResponse {
     let info = db.get_tiles_0_5_info().await?;
     Ok::<_, ApiError>(Json(info))
+}
+
+async fn get_commune_markers(
+    State(db): State<Db>,
+) -> impl IntoApiResponse {
+    let markers = db.get_commune_markers().await?;
+    Ok::<_, ApiError>(Json(ClusterMarkersResponse {
+        markers
+    }))
 }
 
 #[derive(Deserialize, JsonSchema)]

--- a/packages/api/src/routes/schools.rs
+++ b/packages/api/src/routes/schools.rs
@@ -17,6 +17,7 @@ use tokio::try_join;
 pub(crate) fn create_schools_router() -> ApiRouter<Db> {
     ApiRouter::new()
         .api_route("/v1/schools", get(list_schools))
+        .api_route("/v1/tiles/0.5/:tile_lat/:tile_long/schools", get(list_tiles_0_5))
         .api_route("/v1/schools/:rspo_id", get(get_school))
         .api_route(
             "/v1/optivum-versions/:id",
@@ -46,6 +47,22 @@ async fn list_schools(
     }
     let schools = db.get_schools_by_teryt(&params.teryt).await?;
     Ok(Json(SchoolListResponse {
+        schools
+    }))
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct TilesParams {
+    tile_lat: i16,
+    tile_long: i16,
+}
+
+async fn list_tiles_0_5(
+    State(db): State<Db>,
+    Path(params): Path<TilesParams>,
+) -> impl IntoApiResponse {
+    let schools = db.get_tiles_0_5(params.tile_lat, params.tile_long).await?;
+    Ok::<_, ApiError>(Json(SchoolListResponse {
         schools
     }))
 }


### PR DESCRIPTION
Adds new endpoints for school map tiles. The schools are grouped by the 0.5°x0.5 map tile they are in based on their geographical coordinates. 